### PR TITLE
fix typo in dma_tutorial_part1.md

### DIFF
--- a/dma/dma_tutorial_part1.md
+++ b/dma/dma_tutorial_part1.md
@@ -60,7 +60,7 @@ If the IP is not ready to receive data from the M_AXIS port, then this port will
 ### Scatter gather support
 
 PYNQ doesn't support scatter gather functionality of the DMA. This is where data can be transfered from fragmented or disjointed memory locations. PYNQ only supports DMA from contiguous memory buffers. 
-Scatter-Gather can be enabled on the DMA to allow transfers greater than 8MB (from contiguous memory buffers). If you do this, you need to use the SG M_AXI ports instead od the M_AXI ports. This is not covered in this tutorial. 
+Scatter-Gather can be enabled on the DMA to allow transfers greater than 8MB (from contiguous memory buffers). If you do this, you need to use the SG M_AXI ports instead of the M_AXI ports. This is not covered in this tutorial. 
 An alternative to SG for large transfers is to segment your memory transfer in software into <8MB chunks and run multiple DMA transfers. 
 
 ## Configure the DMA

--- a/dma/dma_tutorial_part1.md
+++ b/dma/dma_tutorial_part1.md
@@ -144,7 +144,7 @@ It doesn't matter which HP port a DMA master is connected to.
 
 * Click **OK** to accept the changes
 
-The Block Design shoudl now look like this:
+The Block Design should now look like this:
 
 ![](./images/bd_axis_unconnected.png)
 


### PR DESCRIPTION
fix of a small typo from:
ports instead od the
to:
ports instead of the

and from:
The Block Design shoudl now look like this:
to:
The Block Design should now look like this:

resolves #2 